### PR TITLE
bump monero_c

### DIFF
--- a/cs_monero/lib/src/ffi_bindings/generated_bindings_monero.g.dart
+++ b/cs_monero/lib/src/ffi_bindings/generated_bindings_monero.g.dart
@@ -89,6 +89,24 @@ class FfiMoneroC {
       _MONERO_PendingTransaction_commitURPtr.asFunction<
           ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Void>, int)>();
 
+  ffi.Pointer<ffi.Char> MONERO_PendingTransaction_commitTrezor(
+    ffi.Pointer<ffi.Void> pendingTx_ptr,
+    int tx_index,
+  ) {
+    return _MONERO_PendingTransaction_commitTrezor(
+      pendingTx_ptr,
+      tx_index,
+    );
+  }
+
+  late final _MONERO_PendingTransaction_commitTrezorPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Void>,
+              ffi.Int)>>('MONERO_PendingTransaction_commitTrezor');
+  late final _MONERO_PendingTransaction_commitTrezor =
+      _MONERO_PendingTransaction_commitTrezorPtr.asFunction<
+          ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Void>, int)>();
+
   int MONERO_PendingTransaction_amount(
     ffi.Pointer<ffi.Void> pendingTx_ptr,
   ) {
@@ -3588,6 +3606,24 @@ class FfiMoneroC {
       _MONERO_Wallet_submitTransactionURPtr.asFunction<
           bool Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>)>();
 
+  bool MONERO_Wallet_submitTransactionHex(
+    ffi.Pointer<ffi.Void> wallet_ptr,
+    ffi.Pointer<ffi.Char> hex,
+  ) {
+    return _MONERO_Wallet_submitTransactionHex(
+      wallet_ptr,
+      hex,
+    );
+  }
+
+  late final _MONERO_Wallet_submitTransactionHexPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Bool Function(ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Char>)>>('MONERO_Wallet_submitTransactionHex');
+  late final _MONERO_Wallet_submitTransactionHex =
+      _MONERO_Wallet_submitTransactionHexPtr.asFunction<
+          bool Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>)>();
+
   bool MONERO_Wallet_hasUnknownKeyImages(
     ffi.Pointer<ffi.Void> wallet_ptr,
   ) {
@@ -4504,6 +4540,40 @@ class FfiMoneroC {
   late final _MONERO_Wallet_serializeCacheToJson =
       _MONERO_Wallet_serializeCacheToJsonPtr.asFunction<
           ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Void>)>();
+
+  ffi.Pointer<ffi.Char> MONERO_Wallet_exportTrezorTdis(
+    ffi.Pointer<ffi.Void> wallet_ptr,
+  ) {
+    return _MONERO_Wallet_exportTrezorTdis(
+      wallet_ptr,
+    );
+  }
+
+  late final _MONERO_Wallet_exportTrezorTdisPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ffi.Char> Function(
+              ffi.Pointer<ffi.Void>)>>('MONERO_Wallet_exportTrezorTdis');
+  late final _MONERO_Wallet_exportTrezorTdis =
+      _MONERO_Wallet_exportTrezorTdisPtr.asFunction<
+          ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Void>)>();
+
+  bool MONERO_Wallet_importTrezorEncryptedKeyImagesJson(
+    ffi.Pointer<ffi.Void> wallet_ptr,
+    ffi.Pointer<ffi.Char> json,
+  ) {
+    return _MONERO_Wallet_importTrezorEncryptedKeyImagesJson(
+      wallet_ptr,
+      json,
+    );
+  }
+
+  late final _MONERO_Wallet_importTrezorEncryptedKeyImagesJsonPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Bool Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>)>>(
+      'MONERO_Wallet_importTrezorEncryptedKeyImagesJson');
+  late final _MONERO_Wallet_importTrezorEncryptedKeyImagesJson =
+      _MONERO_Wallet_importTrezorEncryptedKeyImagesJsonPtr.asFunction<
+          bool Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>)>();
 
   ffi.Pointer<ffi.Void> MONERO_WalletManager_createWallet(
     ffi.Pointer<ffi.Void> wm_ptr,

--- a/patches/fix-monero-av.patch
+++ b/patches/fix-monero-av.patch
@@ -1,8 +1,8 @@
 diff --git a/monero_libwallet2_api_c/monero_libwallet2_api_c.exp b/monero_libwallet2_api_c/monero_libwallet2_api_c.exp
-index 1aa2f26..7f3e164 100644
+index d7a404e..30b74d2 100644
 --- a/monero_libwallet2_api_c/monero_libwallet2_api_c.exp
 +++ b/monero_libwallet2_api_c/monero_libwallet2_api_c.exp
-@@ -282,9 +282,6 @@ _MONERO_WalletManager_blockchainTargetHeight
+@@ -286,9 +286,6 @@ _MONERO_WalletManager_blockchainTargetHeight
  _MONERO_WalletManager_networkDifficulty
  _MONERO_WalletManager_miningHashRate
  _MONERO_WalletManager_blockTarget
@@ -12,11 +12,11 @@ index 1aa2f26..7f3e164 100644
  _MONERO_WalletManager_resolveOpenAlias
  _MONERO_WalletManager_setProxy
  _MONERO_WalletManagerFactory_getWalletManager
-diff --git a/monero_libwallet2_api_c/src/main/cpp/wallet2_api_c.cpp b/monero_libwallet2_api_c/src/main/cpp/wallet2_api_c.cpp
-index c58fbec..5239e74 100644
---- a/monero_libwallet2_api_c/src/main/cpp/wallet2_api_c.cpp
-+++ b/monero_libwallet2_api_c/src/main/cpp/wallet2_api_c.cpp
-@@ -2387,27 +2387,6 @@ uint64_t MONERO_WalletManager_blockTarget(void* wm_ptr) {
+diff --git a/monero_libwallet2_api_c/src/main/cpp/monero_wallet2_api_c.cpp b/monero_libwallet2_api_c/src/main/cpp/monero_wallet2_api_c.cpp
+index 5e64296..86daa7a 100644
+--- a/monero_libwallet2_api_c/src/main/cpp/monero_wallet2_api_c.cpp
++++ b/monero_libwallet2_api_c/src/main/cpp/monero_wallet2_api_c.cpp
+@@ -2277,27 +2277,6 @@ uint64_t MONERO_WalletManager_blockTarget(void* wm_ptr) {
      return wm->blockTarget();
      DEBUG_END()
  }
@@ -44,11 +44,11 @@ index c58fbec..5239e74 100644
  //     virtual std::string resolveOpenAlias(const std::string &address, bool &dnssec_valid) const = 0;
  const char* MONERO_WalletManager_resolveOpenAlias(void* wm_ptr, const char* address, bool dnssec_valid) {
      DEBUG_START()
-diff --git a/monero_libwallet2_api_c/src/main/cpp/wallet2_api_c.h b/monero_libwallet2_api_c/src/main/cpp/wallet2_api_c.h
-index ff28d68..e9d6078 100644
---- a/monero_libwallet2_api_c/src/main/cpp/wallet2_api_c.h
-+++ b/monero_libwallet2_api_c/src/main/cpp/wallet2_api_c.h
-@@ -966,12 +966,6 @@ extern ADDAPI uint64_t MONERO_WalletManager_networkDifficulty(void* wm_ptr);
+diff --git a/monero_libwallet2_api_c/src/main/cpp/monero_wallet2_api_c.h b/monero_libwallet2_api_c/src/main/cpp/monero_wallet2_api_c.h
+index eff5c58..e28e71d 100644
+--- a/monero_libwallet2_api_c/src/main/cpp/monero_wallet2_api_c.h
++++ b/monero_libwallet2_api_c/src/main/cpp/monero_wallet2_api_c.h
+@@ -976,12 +976,6 @@ extern ADDAPI uint64_t MONERO_WalletManager_networkDifficulty(void* wm_ptr);
  extern ADDAPI double MONERO_WalletManager_miningHashRate(void* wm_ptr);
  //     virtual uint64_t blockTarget() = 0;
  extern ADDAPI uint64_t MONERO_WalletManager_blockTarget(void* wm_ptr);

--- a/tools/dart/bin/build_libs.dart
+++ b/tools/dart/bin/build_libs.dart
@@ -131,12 +131,38 @@ void main(List<String> args) async {
               "${Platform.pathSeparator}monero_libwallet2_api_c.dll",
         ],
       );
+
+      for (final name in _windowsDlls) {
+        final dll = _windowsDllPath(name);
+        if (!File(dll).existsSync()) {
+          throw Exception(
+            "$dll is missing. The windows package ships it as a commited"
+            " binary; restore it from git before building.",
+          );
+        }
+        await runAsync(
+          "cp",
+          [
+            dll,
+            "${dir.path}"
+                "${Platform.pathSeparator}$name",
+          ],
+        );
+      }
       break;
 
     default:
       throw Exception("Not sure how you got this far tbh");
   }
 }
+
+const _windowsDlls = ["libssp-0.dll", "libwinpthread-1.dll"];
+
+String _windowsDllPath(String name) => "$envProjectDir"
+    "${Platform.pathSeparator}cs_monero_flutter_libs_windows"
+    "${Platform.pathSeparator}windows"
+    "${Platform.pathSeparator}lib"
+    "${Platform.pathSeparator}$name";
 
 /// The tag build_single.sh names its release directory after.
 String _moneroCVersion() {

--- a/tools/dart/bin/build_libs.dart
+++ b/tools/dart/bin/build_libs.dart
@@ -38,16 +38,11 @@ void main(List<String> args) async {
 
   final nProc = _getNProc(platform);
   final triples = _getTriples(platform);
-  final bt = _getBinType(platform);
+  final version = _moneroCVersion();
 
   for (final triple in triples) {
     for (final coin in coins) {
       await runAsync("./build_single.sh", [coin, triple, "-j$nProc"]);
-      final path = "$envMoneroCDir"
-          "${Platform.pathSeparator}release"
-          "${Platform.pathSeparator}$coin"
-          "${Platform.pathSeparator}${triple}_libwallet2_api_c.$bt";
-      await runAsync("unxz", ["-f", "$path.xz"]);
     }
   }
 
@@ -75,10 +70,7 @@ void main(List<String> args) async {
           await runAsync(
             "cp",
             [
-              "$envMoneroCDir"
-                  "${Platform.pathSeparator}release"
-                  "${Platform.pathSeparator}$coin"
-                  "${Platform.pathSeparator}${triple}_libwallet2_api_c.so",
+              _releasedLibPath(version, triple, coin, "so"),
               "${dir.path}"
                   "${Platform.pathSeparator}lib${coin}_libwallet2_api_c.so",
             ],
@@ -99,20 +91,7 @@ void main(List<String> args) async {
 
       // ios and macos only have 1 triple currently
       final triple = _getTriples(platform).first;
-
-      final String xmrDylib;
-      final String wowDylib;
-      if (platform == "ios") {
-        xmrDylib = "$envMoneroCDir"
-            "${Platform.pathSeparator}release"
-            "${Platform.pathSeparator}monero"
-            "${Platform.pathSeparator}${triple}_libwallet2_api_c.dylib";
-      } else {
-        xmrDylib = "$envMoneroCDir"
-            "${Platform.pathSeparator}release"
-            "${Platform.pathSeparator}monero"
-            "${Platform.pathSeparator}${triple}_libwallet2_api_c.dylib";
-      }
+      final xmrDylib = _releasedLibPath(version, triple, "monero", "dylib");
 
       await createFramework(
         frameworkName: "MoneroWallet",
@@ -131,10 +110,7 @@ void main(List<String> args) async {
         await runAsync(
           "cp",
           [
-            "$envMoneroCDir"
-                "${Platform.pathSeparator}release"
-                "${Platform.pathSeparator}$coin"
-                "${Platform.pathSeparator}x86_64-linux-gnu_libwallet2_api_c.so",
+            _releasedLibPath(version, triples.first, coin, "so"),
             "${dir.path}"
                 "${Platform.pathSeparator}${coin}_libwallet2_api_c.so",
           ],
@@ -150,46 +126,9 @@ void main(List<String> args) async {
       await runAsync(
         "cp",
         [
-          "$envMoneroCDir"
-              "${Platform.pathSeparator}release"
-              "${Platform.pathSeparator}monero"
-              "${Platform.pathSeparator}x86_64-w64-mingw32_libwallet2_api_c.dll",
+          _releasedLibPath(version, triples.first, "monero", "dll"),
           "${dir.path}"
               "${Platform.pathSeparator}monero_libwallet2_api_c.dll",
-        ],
-      );
-
-      final sspPath = "$envMoneroCDir"
-          "${Platform.pathSeparator}release"
-          "${Platform.pathSeparator}monero"
-          "${Platform.pathSeparator}x86_64-w64-mingw32_libssp-0.dll";
-
-      if (File("$sspPath.xz").existsSync()) {
-        await runAsync("unxz", ["-f", "$sspPath.xz"]);
-      }
-      await runAsync(
-        "cp",
-        [
-          sspPath,
-          "${dir.path}"
-              "${Platform.pathSeparator}libssp-0.dll",
-        ],
-      );
-
-      final pThreadPath = "$envMoneroCDir"
-          "${Platform.pathSeparator}release"
-          "${Platform.pathSeparator}monero"
-          "${Platform.pathSeparator}x86_64-w64-mingw32_libwinpthread-1.dll";
-
-      if (File("$pThreadPath.xz").existsSync()) {
-        await runAsync("unxz", ["-f", "$pThreadPath.xz"]);
-      }
-      await runAsync(
-        "cp",
-        [
-          pThreadPath,
-          "${dir.path}"
-              "${Platform.pathSeparator}libwinpthread-1.dll",
         ],
       );
       break;
@@ -198,6 +137,32 @@ void main(List<String> args) async {
       throw Exception("Not sure how you got this far tbh");
   }
 }
+
+/// The tag build_single.sh names its release directory after.
+String _moneroCVersion() {
+  final result = Process.runSync(
+    "git",
+    ["describe", "--tags"],
+    workingDirectory: envMoneroCDir,
+  );
+  if (result.exitCode != 0) {
+    throw Exception("code=${result.exitCode}, stderr=${result.stderr}");
+  }
+  return result.stdout.toString().trim();
+}
+
+/// `release/<version>/<triple>/lib<coin>_wallet2_api_c.<ext>`
+String _releasedLibPath(
+  String version,
+  String triple,
+  String coin,
+  String ext,
+) =>
+    "$envMoneroCDir"
+    "${Platform.pathSeparator}release"
+    "${Platform.pathSeparator}$version"
+    "${Platform.pathSeparator}$triple"
+    "${Platform.pathSeparator}lib${coin}_wallet2_api_c.$ext";
 
 String _mapAndroid(String triple) {
   switch (triple) {
@@ -263,24 +228,6 @@ String _getNProc(String platform) {
     case "macos":
     case "windows":
       return nProc.toString();
-
-    default:
-      throw ArgumentError(platform, "platform");
-  }
-}
-
-String _getBinType(String platform) {
-  switch (platform) {
-    case "android":
-    case "linux":
-      return "so";
-
-    case "windows":
-      return "dll";
-
-    case "ios":
-    case "macos":
-      return "dylib";
 
     default:
       throw ArgumentError(platform, "platform");

--- a/tools/dart/env.dart
+++ b/tools/dart/env.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
 const kMoneroCRepo = "https://github.com/MrCyjaneK/monero_c";
-const kMoneroCHash = "07f7a7f80735130ebfa5842ddee5139076408c0d";
+const kMoneroCHash = "3bfb3856a838f2bf6b729501837bb0295dedf25d";
 
 final envProjectDir =
     File.fromUri(Platform.script).parent.parent.parent.parent.path;

--- a/tools/ffi_config/monero.yaml
+++ b/tools/ffi_config/monero.yaml
@@ -3,7 +3,7 @@ description: monero_c bindings
 output: "../../cs_monero/lib/src/ffi_bindings/generated_bindings_monero.g.dart"
 headers:
   entry-points:
-    - "../../build/monero_c/monero_libwallet2_api_c/src/main/cpp/wallet2_api_c.h"
+    - "../../build/monero_c/monero_libwallet2_api_c/src/main/cpp/monero_wallet2_api_c.h"
 
 exclude-all-by-default: true
 functions:


### PR DESCRIPTION
monero_c [v0.18.4.0-RC9](https://github.com/MrCyjaneK/monero_c/releases/tag/v0.18.4.0-RC9) -> [v0.18.4.6-RC2Lat](https://github.com/MrCyjaneK/monero_c/releases/tag/v0.18.4.6-RC2) has some breaking changes which is why some scripts need updating.

I think commits can be kept like this without squashing.
